### PR TITLE
Change default behaviour to forward to git

### DIFF
--- a/bin.sh
+++ b/bin.sh
@@ -211,6 +211,7 @@ gyt() {
     if [ "$#" -eq 0 ]; then
         show_help
     else
+        all_args="$@"
         func="$1"
         shift # Remove function name from arguments
         case "$func" in
@@ -234,8 +235,8 @@ gyt() {
                 freshen-current-branch "$@"
                 ;;
             *)
-                echo "Invalid function name: $func"
-                echo "Use 'gyt help' to see a list of all available commands."
+                echo "gyt: forwarding to git $all_args"
+                git $all_args
                 ;;
         esac
     fi


### PR DESCRIPTION
With this change, when a command is not recognized inside of `gyt`, instead of displaying a message to call `gyt help`, it will forward the arguments to `gyt` to `git`. This way, `gyt` and `git` can be used interchangeably, such that if, i.e., user calls `gyt status` instead of `git status`, the latter will execute.

The potential confusion in case when user actually wants to call a gyt command and calls an invalid one is remediated by the `gyt: forwarding...` message at the top.